### PR TITLE
Network Layer 구현

### DIFF
--- a/RunUs.xcodeproj/project.pbxproj
+++ b/RunUs.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 		D93A94EA2C4A372600BCCD00 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93A94E92C4A372600BCCD00 /* ContentView.swift */; };
 		D93A94EC2C4A372700BCCD00 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D93A94EB2C4A372700BCCD00 /* Assets.xcassets */; };
 		D93A94EF2C4A372700BCCD00 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D93A94EE2C4A372700BCCD00 /* Preview Assets.xcassets */; };
+		D9D0B7182C4F553800D13160 /* RUError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B7172C4F553800D13160 /* RUError.swift */; };
+		D9D0B71A2C4F555500D13160 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B7192C4F555500D13160 /* NetworkError.swift */; };
+		D9D0B71C2C4F566E00D13160 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B71B2C4F566E00D13160 /* NetworkService.swift */; };
+		D9D0B71E2C4F570000D13160 /* NetworkEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B71D2C4F570000D13160 /* NetworkEndpoint.swift */; };
+		D9D0B7202C4FE67D00D13160 /* ServerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B71F2C4FE67D00D13160 /* ServerResponse.swift */; };
+		D9D0B7232C50BA7400D13160 /* ServerNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B7222C50BA7400D13160 /* ServerNetwork.swift */; };
+		D9D0B7252C50BC5800D13160 /* ServerEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D0B7242C50BC5800D13160 /* ServerEndpoint.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +26,13 @@
 		D93A94E92C4A372600BCCD00 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D93A94EB2C4A372700BCCD00 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D93A94EE2C4A372700BCCD00 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		D9D0B7172C4F553800D13160 /* RUError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUError.swift; sourceTree = "<group>"; };
+		D9D0B7192C4F555500D13160 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		D9D0B71B2C4F566E00D13160 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		D9D0B71D2C4F570000D13160 /* NetworkEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEndpoint.swift; sourceTree = "<group>"; };
+		D9D0B71F2C4FE67D00D13160 /* ServerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerResponse.swift; sourceTree = "<group>"; };
+		D9D0B7222C50BA7400D13160 /* ServerNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerNetwork.swift; sourceTree = "<group>"; };
+		D9D0B7242C50BC5800D13160 /* ServerEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerEndpoint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +67,9 @@
 			children = (
 				D93A94E72C4A372600BCCD00 /* RunUsApp.swift */,
 				D93A94E92C4A372600BCCD00 /* ContentView.swift */,
+				D9D0B7172C4F553800D13160 /* RUError.swift */,
+				D9D0B7212C50BA4300D13160 /* Data */,
+				D9D0B7162C4F549D00D13160 /* Network */,
 				D93A94EB2C4A372700BCCD00 /* Assets.xcassets */,
 				D93A94ED2C4A372700BCCD00 /* Preview Content */,
 			);
@@ -65,6 +82,34 @@
 				D93A94EE2C4A372700BCCD00 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		D9D0B7162C4F549D00D13160 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				D9D0B7192C4F555500D13160 /* NetworkError.swift */,
+				D9D0B71B2C4F566E00D13160 /* NetworkService.swift */,
+				D9D0B71D2C4F570000D13160 /* NetworkEndpoint.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		D9D0B7212C50BA4300D13160 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				D9D0B7262C50C42400D13160 /* Server */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		D9D0B7262C50C42400D13160 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				D9D0B7222C50BA7400D13160 /* ServerNetwork.swift */,
+				D9D0B7242C50BC5800D13160 /* ServerEndpoint.swift */,
+				D9D0B71F2C4FE67D00D13160 /* ServerResponse.swift */,
+			);
+			path = Server;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,8 +182,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9D0B71C2C4F566E00D13160 /* NetworkService.swift in Sources */,
 				D93A94EA2C4A372600BCCD00 /* ContentView.swift in Sources */,
+				D9D0B71A2C4F555500D13160 /* NetworkError.swift in Sources */,
+				D9D0B7182C4F553800D13160 /* RUError.swift in Sources */,
+				D9D0B7252C50BC5800D13160 /* ServerEndpoint.swift in Sources */,
+				D9D0B7202C4FE67D00D13160 /* ServerResponse.swift in Sources */,
+				D9D0B71E2C4F570000D13160 /* NetworkEndpoint.swift in Sources */,
 				D93A94E82C4A372600BCCD00 /* RunUsApp.swift in Sources */,
+				D9D0B7232C50BA7400D13160 /* ServerNetwork.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RunUs/Data/Server/ServerEndpoint.swift
+++ b/RunUs/Data/Server/ServerEndpoint.swift
@@ -1,0 +1,20 @@
+//
+//  ServerEndpoint.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/24/24.
+//
+
+import Foundation
+
+//TODO: Server 나오면 수정
+enum ServerEndpoint: NetworkEndpoint {
+    case test
+    
+    var baseURL: URL? { nil }
+    var path: String { "" }
+    var method: NetworkMethod { .get }
+    var parameters: [URLQueryItem]? { nil }
+    var header: [String : String]? { nil }
+    var body: Data? { nil }
+}

--- a/RunUs/Data/Server/ServerNetwork.swift
+++ b/RunUs/Data/Server/ServerNetwork.swift
@@ -1,0 +1,45 @@
+//
+//  ServerNetwork.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/24/24.
+//
+
+import Foundation
+import Combine
+
+class ServerNetwork {
+    static let shared = ServerNetwork()
+    
+    private init() { }
+    
+    func request<T: Decodable>(_ endpoint: ServerEndpoint) -> AnyPublisher<T, NetworkError> {
+        NetworkService.shared.request(endpoint)
+            .tryMap { (response: ServerResponse<T>) in
+                if let data = response.data, response.success {
+                    return data
+                } else if let error = response.error {
+                    throw NetworkError.server(code: error.statusCode)
+                } else {
+                    throw NetworkError.parse
+                }
+            }
+            .mapError{ _ in NetworkError.unknown }
+            .eraseToAnyPublisher()
+    }
+    
+    func request(_ endpoint: ServerEndpoint) -> AnyPublisher<Void, NetworkError> {
+        NetworkService.shared.request(endpoint)
+            .tryMap { (response: ServerResponse<Bool>) in
+                if response.success {
+                    return
+                } else if let error = response.error {
+                    throw NetworkError.server(code: error.statusCode)
+                } else {
+                    throw NetworkError.parse
+                }
+            }
+            .mapError{ _ in NetworkError.unknown }
+            .eraseToAnyPublisher()
+    }
+}

--- a/RunUs/Data/Server/ServerResponse.swift
+++ b/RunUs/Data/Server/ServerResponse.swift
@@ -1,0 +1,20 @@
+//
+//  ServerResponse.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/23/24.
+//
+
+import Foundation
+
+struct ServerResponse<T: Decodable>: Decodable {
+    let success: Bool
+    let data: T?
+    let error: ServerError?
+}
+
+struct ServerError: Decodable {
+    let statusCode: Int
+    let code: String
+    let message: String
+}

--- a/RunUs/Network/NetworkEndpoint.swift
+++ b/RunUs/Network/NetworkEndpoint.swift
@@ -1,0 +1,23 @@
+//
+//  Endpoint.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/23/24.
+//
+
+import Foundation
+
+protocol NetworkEndpoint {
+    var baseURL: URL? { get }
+    var path: String { get }
+    var method: NetworkMethod { get }
+    var parameters: [URLQueryItem]? { get }
+    var header: [String: String]? { get }
+    var body: Data? { get }
+}
+
+enum NetworkMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case delete = "DELETE"
+}

--- a/RunUs/Network/NetworkError.swift
+++ b/RunUs/Network/NetworkError.swift
@@ -1,0 +1,28 @@
+//
+//  ServerError.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/23/24.
+//
+
+import Foundation
+
+enum NetworkError: RUError {
+    case request
+    case parse
+    case server(code: Int)
+    case unknown
+    
+    var description: String {
+        switch self {
+        case .request:
+            return "잘못된 요청입니다"
+        case .parse:
+            return "데이터 형식이 잘못되었습니다"
+        case .server(let code):
+            return "서버 에러 입니다: \(code)"
+        case .unknown:
+            return "문제가 발생했습니다"
+        }
+    }
+}

--- a/RunUs/Network/NetworkService.swift
+++ b/RunUs/Network/NetworkService.swift
@@ -1,0 +1,58 @@
+//
+//  NetworkService.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/23/24.
+//
+
+import Foundation
+import Combine
+
+class NetworkService {
+    static let shared = NetworkService()
+    
+    private init() { }
+    
+    func request<T: Decodable>(_ endpoint: NetworkEndpoint) -> AnyPublisher<T, NetworkError> {
+        guard let url = configureURL(endpoint) else {
+            return Fail<T, NetworkError>(error: NetworkError.request)
+                .eraseToAnyPublisher()
+        }
+        let request = configureRequest(url: url, endpoint)
+        
+        return URLSession.shared.dataTaskPublisher(for: request)
+            .mapError{ NetworkError.server(code: $0.errorCode) }
+            .map(\.data)
+            .decode(type: T.self, decoder: JSONDecoder())
+            .mapError { _ in NetworkError.parse }
+            .eraseToAnyPublisher()
+    }
+    
+    private func configureURL(_ endpoint: NetworkEndpoint) -> URL? {
+        guard let baseURL = endpoint.baseURL else { return nil }
+        let url = baseURL.appendingPathComponent(endpoint.path)
+        
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return nil}
+        components.queryItems = endpoint.parameters
+        
+        return components.url
+    }
+    
+    private func configureRequest(url: URL, _ endpoint: NetworkEndpoint) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        
+        if let header = endpoint.header {
+            for (key,value) in header {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+        }
+        
+        if let body = endpoint.body {
+            request.httpBody = try? JSONEncoder().encode(body)
+        }
+        
+        return request
+    }
+}
+

--- a/RunUs/RUError.swift
+++ b/RunUs/RUError.swift
@@ -1,0 +1,10 @@
+//
+//  RUError.swift
+//  RunUs
+//
+//  Created by Ryeong on 7/23/24.
+//
+
+import Foundation
+
+protocol RUError: Error { }


### PR DESCRIPTION
## ⭐️ 요청 사항
- [x] 코드 리뷰를 07.29(월) 까지 부탁드려요 🙋🏻
- [x] **네이밍 컨벤션**을 꼼꼼히 봐주세요
- [x] **오탈자**를 꼼꼼히 봐주세요
- [ ] **알고리즘**을 꼼꼼히 봐주세요
- [ ] **비즈니스 로직**이 정확한지 확인해 주세요
- [x] **빌드**해서 정상적으로 동작하는지 확인해 주세요
- [x] 아래에 있는 코드를 통해 `NetworkService`의 정상 동작을 확인해 주세요

## issue number
- #1 

## 요약
- 네트워크 통신에 필요한 객체들을 만들었어요

## 변경 사항
- `ServerResponse`: 서버와의 회의를 통해 정의된 통신 모델
  - 매 통신마다 바뀔 data의 데이터 타입을 제네릭하게 받을 수 있도록 했어요
- `NetworkService`: request를 위한 범용 통신 객체
  - 어떤 Endpoint에서도 사용할 수 있도록 구현하고자 했어요
  - `request(_:)` 를 제네릭하게 만들어 파싱 로직을 재사용 할 수 있게 했어요
- `NetworkEndpoint`: 네트워크 통신에 필요한 요청 모델을 만들기 위한 프로토콜 (인터페이스)
- `ServerNetwork`: 서버와 통신하기 위한 통신 객체
  - 서버와 항상 `ServerResponse`를 통해 통신하기 때문에, decode 중복 제거를 위해 만든 객체에요
  - 내부에서 NetworkService를 호출해요

## 테스트 요청
- 아래 코드를 통해 `NetworkService`의 정상 동작 여부를 확인해 주세요

```swift
import Combine

enum TestAPI: NetworkEndpoint {
    case todos
    
    var baseURL: URL? { URL(string: "https://jsonplaceholder.typicode.com") }
    var path: String {
        switch self {
        case .todos:
            return "todos/0"
        }
    }
    var method: NetworkMethod { .get }
    var parameters: [URLQueryItem]? { nil }
    var header: [String : String]? { nil }
    var body: Data? { nil }
}

struct Todo: Decodable { }

class TestNetwork {
    static let shared = TestNetwork()
    var cancellable = Set<AnyCancellable>()
    
    func getTodos() {
        let _ = NetworkService.shared.request(TestAPI.todos)
            .sink { completion in
                switch completion {
                case .finished:
                    print("finished")
                case .failure(let error):
                    print("failure \(error)")
                }
            } receiveValue: { (todo: Todo) in
                print(todo)
            }.store(in: &cancellable)
    }
}
``` 
<img width="518" alt="image" src="https://github.com/user-attachments/assets/84088fcd-924e-490f-8fc3-6f81bd44441d">


