### PR TITLE
Server Base API 구현

### DIFF
--- a/RunUs/Data/Server/ServerEndpoint.swift
+++ b/RunUs/Data/Server/ServerEndpoint.swift
@@ -7,14 +7,42 @@
 
 import Foundation
 
-//TODO: Server 나오면 수정
 enum ServerEndpoint: NetworkEndpoint {
-    case test
+    case testRequest(string: String)
+    case testResponse
+    case testError
     
-    var baseURL: URL? { nil }
-    var path: String { "" }
-    var method: NetworkMethod { .get }
-    var parameters: [URLQueryItem]? { nil }
+    var baseURL: URL? { URL(string: "https://api.runus.site") }
+    
+    enum APIversion {
+        static let v1 = "/api/v1"
+    }
+    
+    var path: String {
+        switch self {
+        case .testRequest:
+            return APIversion.v1 + "/examples/input"
+        case .testResponse:
+            return APIversion.v1 + "/examples/empty"
+        case .testError:
+            return APIversion.v1 + "/examples/errors"
+        }
+    }
+    
+    var method: NetworkMethod {
+        switch self {
+        case .testRequest, .testResponse, .testError:
+            return .get
+        }
+    }
+    var parameters: [URLQueryItem]? {
+        switch self {
+        case .testRequest(let string):
+            return [.init(name: "input", value: string)]
+        case .testResponse, .testError:
+            return nil
+        }
+    }
     var header: [String : String]? { nil }
     var body: Data? { nil }
 }

--- a/RunUs/Data/Server/ServerNetwork.swift
+++ b/RunUs/Data/Server/ServerNetwork.swift
@@ -19,7 +19,7 @@ class ServerNetwork {
                 if let data = response.data, response.success {
                     return data
                 } else if let error = response.error {
-                    throw NetworkError.server(code: error.statusCode)
+                    throw NetworkError.server(error: error)
                 } else {
                     throw NetworkError.parse
                 }
@@ -36,11 +36,11 @@ class ServerNetwork {
     
     func request(_ endpoint: ServerEndpoint) -> AnyPublisher<Void, NetworkError> {
         NetworkService.shared.request(endpoint)
-            .tryMap { (response: ServerResponse<Bool>) in
+            .tryMap { (response: ServerResponse<EmptyData>) in
                 if response.success {
                     return
                 } else if let error = response.error {
-                    throw NetworkError.server(code: error.statusCode)
+                    throw NetworkError.server(error: error)
                 } else {
                     throw NetworkError.parse
                 }

--- a/RunUs/Data/Server/ServerNetwork.swift
+++ b/RunUs/Data/Server/ServerNetwork.swift
@@ -24,7 +24,13 @@ class ServerNetwork {
                     throw NetworkError.parse
                 }
             }
-            .mapError{ _ in NetworkError.unknown }
+            .mapError{ error -> NetworkError in
+                if let networkError = error as? NetworkError {
+                    return networkError
+                } else {
+                    return NetworkError.unknown
+                }
+            }
             .eraseToAnyPublisher()
     }
     
@@ -39,7 +45,13 @@ class ServerNetwork {
                     throw NetworkError.parse
                 }
             }
-            .mapError{ _ in NetworkError.unknown }
+            .mapError{ error -> NetworkError in
+                if let networkError = error as? NetworkError {
+                    return networkError
+                } else {
+                    return NetworkError.unknown
+                }
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/RunUs/Data/Server/ServerResponse.swift
+++ b/RunUs/Data/Server/ServerResponse.swift
@@ -13,6 +13,8 @@ struct ServerResponse<T: Decodable>: Decodable {
     let error: ServerError?
 }
 
+struct EmptyData: Decodable { }
+
 struct ServerError: Decodable {
     let statusCode: Int
     let code: String

--- a/RunUs/Network/NetworkError.swift
+++ b/RunUs/Network/NetworkError.swift
@@ -10,7 +10,7 @@ import Foundation
 enum NetworkError: RUError {
     case request
     case parse
-    case server(code: Int)
+    case server(error: ServerError)
     case unknown
     
     var description: String {

--- a/RunUs/Network/NetworkService.swift
+++ b/RunUs/Network/NetworkService.swift
@@ -21,7 +21,7 @@ class NetworkService {
         let request = configureRequest(url: url, endpoint)
         
         return URLSession.shared.dataTaskPublisher(for: request)
-            .mapError{ NetworkError.server(code: $0.errorCode) }
+            .mapError { _ in NetworkError.request }
             .map(\.data)
             .decode(type: T.self, decoder: JSONDecoder())
             .mapError { _ in NetworkError.parse }


### PR DESCRIPTION
## ⭐️ 요청 사항
- [x] 코드 리뷰를 07.31 까지 부탁드려요 🙋🏻
- [x] **네이밍 컨벤션**을 꼼꼼히 봐주세요
- [x] **오탈자**를 꼼꼼히 봐주세요
- [x] **알고리즘**을 꼼꼼히 봐주세요
- [ ] **비즈니스 로직**이 정확한지 확인해 주세요
- [ ] **빌드**해서 정상적으로 동작하는지 확인해 주세요

## issue number
- #8 

## 요약
- `ServerEndpoint`를 [Swagger](https://api.runus.site/swagger-ui/index.html)에 맞춰 수정했어요

## 변경 사항
- server API 매핑 로직을 변경했어요
  - 기존 코드는 서버에러를 모두 unknown로 받아요
  - 수정하면 throw된 에러 타입을 추출할 수 있어요
  ```Swift
            .mapError{ error -> NetworkError in
                if let networkError = error as? NetworkError {
                    return networkError
                } else {
                    return NetworkError.unknown
                }
            }
  ```
- `EmptyData`를 통해 json에서 data: {} 가 왔을 때 파싱할 수 있도록 해요
- 그 외 변경 사항은 커밋로그를 통해 쉽게 알 수 있는 내용이에요

## 스크린샷
- input test
![image](https://github.com/user-attachments/assets/7c3c8bb4-140c-4ba2-b8c3-5386e3265272)

- empty data test 
![image](https://github.com/user-attachments/assets/b6ac35f4-97b4-47c5-b605-2121ecd9f008)

- error test
![image](https://github.com/user-attachments/assets/44b157fd-4d6c-44e8-a0fa-f759cdfe96e6)


