### PR TITLE
MyRecordView UI 개선 및 일부 수정

### DIFF
--- a/RunUs/Record/BadgesResponseModel.swift
+++ b/RunUs/Record/BadgesResponseModel.swift
@@ -15,5 +15,5 @@ struct Badge: Decodable, Equatable {
     var badgeId: Int = 0
     var name: String = ""
     var imageUrl: String = ""
-    var achieveAt: String = ""
+    var achievedAt: String = ""
 }

--- a/RunUs/Record/MyBadges.swift
+++ b/RunUs/Record/MyBadges.swift
@@ -24,8 +24,8 @@ struct MyBadges: View {
             } else {
                 // TODO: 미리 보기 뱃지 갯수 정의 (ex: 미리 보기 뱃지는 3개로 고정) 이후 수정
                 VStack {
-                    ForEach (0 ... (badges.count / 3), id: \.self) { rowIndex in
-                        HStack(spacing: 0) {
+                    ForEach (0 ... ((badges.count - 1) / 3), id: \.self) { rowIndex in
+                        HStack(spacing: 3) {
                             MyBadge(badge: badges[rowIndex * 3])
                             MyBadge(badge: badges.count > rowIndex * 3 + 1 ? badges[rowIndex * 3 + 1] : nil)
                             MyBadge(badge: badges.count > rowIndex * 3 + 2 ? badges[rowIndex * 3 + 2] : nil)
@@ -46,18 +46,18 @@ struct MyBadge: View {
             if badge == nil {
                 Image(.xmark)  // MARK: empty Image
                     .resizable()
-                    .scaledToFit()
-                    .padding(50)
+                    .aspectRatio(1, contentMode: .fit)
                     .opacity(0)
             } else {
                 AsyncImage(url: URL(string: badge!.imageUrl)) { image in
                     image
                         .resizable()
-                        .scaledToFit()
-                        .padding(25)
                 } placeholder: {
                     ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
+                .aspectRatio(1, contentMode: .fit)
+                .padding(13)
                 Text(badge!.name)
                     .font(.system(size: 12))
                     .foregroundStyle(.gray200)

--- a/RunUs/Record/MyRecordView.swift
+++ b/RunUs/Record/MyRecordView.swift
@@ -64,7 +64,7 @@ extension MyRecordView {
             MyRecordButton(action: {
                 // TODO: 나의 뱃지 화면으로 이동
             }, text: "나의 뱃지")
-            .padding(.bottom, 18)
+            .padding(.bottom, 12)
             MyBadges(badges: store.badges)
             Divider()
                 .frame(maxWidth: .infinity)

--- a/RunUs/Record/MyRecordView.swift
+++ b/RunUs/Record/MyRecordView.swift
@@ -52,8 +52,8 @@ extension MyRecordView {
                         .scaledToFit()
                 } placeholder: {
                     ProgressView()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxWidth: 100, maxHeight: .infinity) // MARK: 임의 Width 사용
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .aspectRatio(1, contentMode: .fit)
                 }
             }
             .frame(maxHeight: 86)

--- a/RunUs/Record/MyRecordView.swift
+++ b/RunUs/Record/MyRecordView.swift
@@ -66,10 +66,10 @@ extension MyRecordView {
             }, text: "나의 뱃지")
             .padding(.bottom, 12)
             MyBadges(badges: store.badges)
-            Divider()
+            Rectangle()
+                .fill(.mainDeepDark)
                 .frame(maxWidth: .infinity)
                 .frame(height: 8)
-                .background(.mainDeepDark)
                 .padding(.horizontal, -Paddings.outsideHorizontalPadding)
                 .padding(.bottom, 12)
             MyRecordButton(action: {

--- a/RunUs/Record/ProfileResponseModel.swift
+++ b/RunUs/Record/ProfileResponseModel.swift
@@ -15,9 +15,9 @@ struct ProfileResponseModel: Decodable, Equatable {
     
     init() {
         self.profileImageUrl = ""
-        self.currentKm = ""
-        self.nextLevelName = ""
-        self.nextLevelKm = ""
+        self.currentKm = "0km"
+        self.nextLevelName = "Level 0"
+        self.nextLevelKm = "0Km"
     }
     
     init(_ profileImageUrl: String, _ currentKm: String, _ nextLevelName: String, _ nextLevelKm: String) {


### PR DESCRIPTION
## ⭐️ 요청 사항
- [ ] 코드 리뷰를 xx.xx 까지 부탁드려요 🙋🏻
- [ ] **네이밍 컨벤션**을 꼼꼼히 봐주세요
- [ ] **오탈자**를 꼼꼼히 봐주세요
- [ ] **알고리즘**을 꼼꼼히 봐주세요
- [ ] **비즈니스 로직**이 정확한지 확인해 주세요
- [x] **빌드**해서 정상적으로 동작하는지 확인해 주세요

## 테스트를 위해 필요한 내용
- 뱃지 이미지까지 확인하고 싶으시다면 백엔드 분들에게 뱃지를 넣어달라고 요청해야해요
- MainView에서 HomeView -> MyRecordView로 수정해서 테스트해야해요

## issue number
- #48 

## 요약
- MyRecordView의 UI를 개선하고 일부 잘못되어있는 내용(오탈자와 일부 알고리즘)을 수정했어요

## 변경 사항
- `MyBadges`
  - 뱃지가 3의 배수개 있을 때 반복문이 한 번씩 더 도는 에러가 있어서 count -1로 알고리즘을 수정했어요
  - 빈 이미지, ProgressView, 뱃지 이미지들의 UI를 규격화했어요
- `MyRecordView`: 
  - 디자이너분들과 협의한 내용대로 공백 간격을 수정했어요
  - 두꺼운 구분선을 Divider에서 Rectangle로 수정했어요
  - 레벨 이미지의 ProgressView 크기를 비율로 지정하도록 수정했어요
- `BadgesResponseModel`: 오탈자를 수정했어요
- `ProfileResponseModel`: API통신 전에 보여질 기본 값들을 추가했어요

## 스크린샷
<img width="275" alt="image" src="https://github.com/user-attachments/assets/4e50d1c1-880c-44b6-a78b-5132a83de0b5">

