### PR TITLE
로딩뷰를 구현해요

### DIFF
--- a/RunUs.xcodeproj/project.pbxproj
+++ b/RunUs.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		D9F5B85A2C60EDD0009CEB19 /* RunAloneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F5B8592C60EDD0009CEB19 /* RunAloneView.swift */; };
 		D9F5B85C2C60EE1E009CEB19 /* RunAloneFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F5B85B2C60EE1E009CEB19 /* RunAloneFeature.swift */; };
 		F6016DC52CC51F2600FB637F /* WithdrawResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6016DC42CC51F2600FB637F /* WithdrawResponseModel.swift */; };
+		F605C0D42CD6644200562EAF /* LoadingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605C0D32CD6644200562EAF /* LoadingManager.swift */; };
+		F605C0D62CD6683400562EAF /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605C0D52CD6683400562EAF /* LoadingView.swift */; };
 		F611B21A2C7CB04100797470 /* AuthorizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F611B2192C7CB04100797470 /* AuthorizationManager.swift */; };
 		F611B21C2C7E1A7300797470 /* HomeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F611B21B2C7E1A7300797470 /* HomeStore.swift */; };
 		F611B2202C7E1FBE00797470 /* WeatherResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F611B21F2C7E1FBE00797470 /* WeatherResponseModel.swift */; };
@@ -160,6 +162,8 @@
 		D9F5B8592C60EDD0009CEB19 /* RunAloneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunAloneView.swift; sourceTree = "<group>"; };
 		D9F5B85B2C60EE1E009CEB19 /* RunAloneFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunAloneFeature.swift; sourceTree = "<group>"; };
 		F6016DC42CC51F2600FB637F /* WithdrawResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawResponseModel.swift; sourceTree = "<group>"; };
+		F605C0D32CD6644200562EAF /* LoadingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingManager.swift; sourceTree = "<group>"; };
+		F605C0D52CD6683400562EAF /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		F611B2192C7CB04100797470 /* AuthorizationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationManager.swift; sourceTree = "<group>"; };
 		F611B21B2C7E1A7300797470 /* HomeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStore.swift; sourceTree = "<group>"; };
 		F611B21F2C7E1FBE00797470 /* WeatherResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponseModel.swift; sourceTree = "<group>"; };
@@ -374,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				F6EF88732C4E7FF5008EF2FD /* SplashView.swift */,
+				F605C0D52CD6683400562EAF /* LoadingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -405,6 +410,7 @@
 				F69BFDA72C897DA90073775C /* AlertEnvironment.swift */,
 				F63BAA502C86C8E900DCE9EC /* ViewEnvironment.swift */,
 				F69BFDA92C8B64070073775C /* VersionResponseModel.swift */,
+				F605C0D32CD6644200562EAF /* LoadingManager.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -664,6 +670,7 @@
 				F65033D92C75D21800C81DA6 /* WithdrawRequestModel.swift in Sources */,
 				D9D0B7202C4FE67D00D13160 /* ServerResponse.swift in Sources */,
 				F674843A2CAE53DA00AA5256 /* MainAPI.swift in Sources */,
+				F605C0D42CD6644200562EAF /* LoadingManager.swift in Sources */,
 				D95F83132C6FAC76000DCAA3 /* Int+extension.swift in Sources */,
 				D9D0B71E2C4F570000D13160 /* NetworkEndpoint.swift in Sources */,
 				F664670B2CA3F01500508369 /* GoalResult.swift in Sources */,
@@ -713,6 +720,7 @@
 				F6EF887D2C4F7E46008EF2FD /* HomeView.swift in Sources */,
 				F66467172CA52E0600508369 /* RunningRecord.swift in Sources */,
 				F680B9EA2C8DF51E00478E30 /* RunningRecordResponseModel.swift in Sources */,
+				F605C0D62CD6683400562EAF /* LoadingView.swift in Sources */,
 				D9D4387C2C7F488E00F3E079 /* RunningRecordView.swift in Sources */,
 				F69BFDA42C8968030073775C /* CoursesResponseModel.swift in Sources */,
 				F6AC52E02C662DEE00654820 /* UserDefaultManager.swift in Sources */,

--- a/RunUs/Core/LoadingManager.swift
+++ b/RunUs/Core/LoadingManager.swift
@@ -1,0 +1,33 @@
+//
+//  LoadingManager.swift
+//  RunUs
+//
+//  Created by seungyooooong on 11/2/24.
+//
+
+import Foundation
+
+class LoadingManager: ObservableObject {
+    static let shared = LoadingManager()
+    private init() { }
+    
+    private var loadingCount = 0
+    @Published private(set) var isLoading = false
+    
+    func startLoading() {
+        DispatchQueue.main.async {
+            self.loadingCount += 1
+            self.isLoading = true
+        }
+    }
+    
+    func stopLoading() {
+        DispatchQueue.main.async {
+            self.loadingCount -= 1
+            if self.loadingCount <= 0 {
+                self.loadingCount = 0
+                self.isLoading = false
+            }
+        }
+    }
+}

--- a/RunUs/Core/View/LoadingView.swift
+++ b/RunUs/Core/View/LoadingView.swift
@@ -1,0 +1,20 @@
+//
+//  LoadingView.swift
+//  RunUs
+//
+//  Created by seungyooooong on 11/2/24.
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        ProgressView()
+            .frame(maxWidth:. infinity, maxHeight: .infinity)
+            .background(Color.background.opacity(0.2))
+    }
+}
+
+#Preview {
+    LoadingView()
+}

--- a/RunUs/Core/View/LoadingView.swift
+++ b/RunUs/Core/View/LoadingView.swift
@@ -8,10 +8,24 @@
 import SwiftUI
 
 struct LoadingView: View {
+    @State var isShowLoading = false
+    @State var timer: Timer?
+    
     var body: some View {
         ProgressView()
+            .opacity(isShowLoading ? 1 : 0)
             .frame(maxWidth:. infinity, maxHeight: .infinity)
-            .background(Color.background.opacity(0.2))
+            .background(Color.background.opacity(isShowLoading ? 0.5 : 0.01))
+            .onAppear {
+                timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { timer in
+                    isShowLoading = true
+                }
+            }
+            .onDisappear {
+                timer?.invalidate()
+                timer = nil
+                isShowLoading = false
+            }
     }
 }
 

--- a/RunUs/Network/Server/ServerNetwork.swift
+++ b/RunUs/Network/Server/ServerNetwork.swift
@@ -56,6 +56,9 @@ class ServerNetwork {
     }
     
     func request<T: Decodable>(_ endpoint: ServerEndpoint) async throws -> T {
+        LoadingManager.shared.startLoading()
+        defer { LoadingManager.shared.stopLoading() }
+        
         do {
             let response: ServerResponse<T> = try await NetworkService.shared.request(endpoint)
             
@@ -72,6 +75,9 @@ class ServerNetwork {
     }
     
     func request(_ endpoint: ServerEndpoint) async throws -> Void {
+        LoadingManager.shared.startLoading()
+        defer { LoadingManager.shared.stopLoading() }
+        
         do {
             let response: ServerResponse<EmptyData> = try await NetworkService.shared.request(endpoint)
             

--- a/RunUs/RunUsApp.swift
+++ b/RunUs/RunUsApp.swift
@@ -12,6 +12,7 @@ struct RunUsApp: App {
     @State var isLoading: Bool = true
     @StateObject private var alertEnvironment = AlertEnvironment()
     @StateObject private var viewEnvironment = ViewEnvironment()
+    @StateObject private var loadingManager = LoadingManager.shared
     
     var body: some Scene {
         WindowGroup {
@@ -27,6 +28,7 @@ extension RunUsApp {
             if isLoading { SplashView(isLoading: $isLoading) }
             else { MainView().environmentObject(viewEnvironment) }
             if alertEnvironment.isShowAlert { alertEnvironment.ruAlert }
+            if loadingManager.isLoading { LoadingView() }
         }
         .onAppear{
             _ = LocationManager.shared


### PR DESCRIPTION
## issue number
- #45 

## 요약
- 서버와 통신중임을 사용자들에게 시각적으로 보여주고, 사용자 인터렉션을 막는 로딩뷰를 만들었어요

## 변경 사항
- LoadingManager를 만들었어요
- ServerNetwork의 request에서 진입 시 start, defer를 통해 종료 시 stop을 구현했어요
- 로딩뷰는 자체적으로 timer와 isShowLoading 변수를 가지고 있어 1초 미만의 통신에서는 사용자 인터렉션만을 막고, 1초 이상의 통신에서는 로딩뷰를 보여줘요

## 스크린샷
<img width="200" alt="image" src="https://github.com/user-attachments/assets/7e4fcb40-6e51-4506-9794-0eb354dad007">
